### PR TITLE
Licensed as the original English version

### DIFF
--- a/01-introducao.tex
+++ b/01-introducao.tex
@@ -1,4 +1,4 @@
-% upstream: b6ae800cfd028b850bbe3a04889b1a7f04372082
+% upstream: efcbde4fdfb5987f4ef7d613761d801c10742ec0
 
 \chapter{Introdução}
 \label{introduction}
@@ -78,6 +78,13 @@ A maior parte do conteúdo desse documento foi escrita por Simon Krajewski, enqu
 	\item Nicolas Cannasse: Criador do Haxe
 	\translationextra{\item Arthur Szász: Primeiro esforço de tradução para o Português}
 \end{itemize}
+
+\subsection{Licença}
+\label{introduction-license}
+
+O Manual do Haxe da \href{http://haxe.org/foundation}{Haxe Foundation} está licenciado sob a \href{http://creativecommons.org/licenses/by/4.0/}{Creative Commons Attribution 4.0 International License}.
+
+Baseado nos trabalhos em \href{https://github.com/HaxeFoundation/HaxeManual}{https://github.com/HaxeFoundation/HaxeManual} e\\ \href{https://github.com/aszasz/Manual\_do\_Haxe}{https://github.com/aszasz/Manual\_do\_Haxe}.
 
 \section{Hello World}
 \label{introduction-hello-world}


### PR DESCRIPTION
@aszasz, prease check if you agree with the following:
- Copyright _might_ implicitly go to the HaxeFoundation (although projects like the Linux kernel base copyright on the git logs).
- The content will be licensed under a very permissive license, and the only requirement for any use (commercial or not) will be attribution of appropriate credit. In the current wording this might erroneously only go to the HaxeFoundation...

This updates the introduction to the last original commit.
